### PR TITLE
fix: remove all sound fallback mechanisms

### DIFF
--- a/template/play_sound.js
+++ b/template/play_sound.js
@@ -17,22 +17,10 @@ const hookName = process.argv[2];
 const homeDir = os.homedir();
 const configFile = path.join(homeDir, '.claude-gamify', 'config.json');
 const themesBase = path.join(homeDir, '.claude-gamify', 'themes');
-const systemSounds = '/System/Library/Sounds';
 
 // Platform detection
 const isMacOS = process.platform === 'darwin';
 const isLinux = process.platform === 'linux';
-
-// macOS system sound mappings (fallback when theme sounds not found)
-const macOSSystemSounds = {
-  SessionStart: 'Hero.aiff',
-  UserPromptSubmit: 'Pop.aiff', 
-  PreToolUse: 'Tink.aiff',
-  PostToolUse: 'Glass.aiff',
-  Notification: 'Ping.aiff',
-  Stop: 'Funk.aiff',
-  SubagentStop: 'Glass.aiff'
-};
 
 /**
  * Load configuration from JSON file
@@ -59,7 +47,7 @@ function loadConfig() {
 function findSoundPath(hookName, currentTheme) {
   const extensions = ['.aiff', '.mp3', '.wav'];
   
-  // Priority 1: Theme directory (by hook name)
+  // Only look in the current theme directory - no fallbacks
   const themeDir = path.join(themesBase, currentTheme);
   if (fs.existsSync(themeDir)) {
     for (const ext of extensions) {
@@ -70,28 +58,7 @@ function findSoundPath(hookName, currentTheme) {
     }
   }
   
-  // Priority 2: System theme directory (cross-platform fallback)
-  const systemDir = path.join(themesBase, 'system');
-  if (fs.existsSync(systemDir)) {
-    for (const ext of extensions) {
-      const systemPath = path.join(systemDir, hookName + ext);
-      if (fs.existsSync(systemPath)) {
-        return systemPath;
-      }
-    }
-  }
-  
-  // Priority 3: macOS system sounds (macOS only)
-  if (isMacOS) {
-    const systemSoundFile = macOSSystemSounds[hookName];
-    if (systemSoundFile) {
-      const systemPath = path.join(systemSounds, systemSoundFile);
-      if (fs.existsSync(systemPath)) {
-        return systemPath;
-      }
-    }
-  }
-  
+  // No sound found - return null (fail silently)
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Removed all fallback mechanisms from the sound player
- Sounds now only play from the active theme directory
- Silent failure when sound files are not found (no system defaults)

## Changes

This PR simplifies the sound resolution logic in `template/play_sound.js`:

1. **Removed macOS system sound fallbacks** - No longer attempts to use `/System/Library/Sounds/`
2. **Removed system theme fallback** - No longer checks `~/.claude-gamify/themes/system/`
3. **Simplified to single source** - Only looks in the active theme directory

## Behavior

- **Before**: Sound player would fall back to system theme, then macOS system sounds if theme sounds were missing
- **After**: Sound player only plays sounds from the selected theme, fails silently if not found

This creates more predictable behavior where sounds are strictly theme-specific with no unexpected defaults.

## Test Plan

- [x] Verify sound plays when file exists in active theme
- [x] Verify silent failure when sound file is missing
- [x] Ensure no errors block Claude Code hooks